### PR TITLE
Disable actionmailbox and actioncable railties to prevent the routes …

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,23 @@
+# frozen_string_literal: true
+
 require_relative "boot"
 
-require "rails/all"
+require 'rails'
+
+# exclude action_mailbox and action_cable which are pulled in by rails/all but create unused routes
+%w[
+  active_record/railtie
+  active_storage/engine
+  action_controller/railtie
+  action_view/railtie
+  action_mailer/railtie
+  active_job/railtie
+  action_text/engine
+  rails/test_unit/railtie
+  sprockets/railtie
+].each do |railtie|
+  require railtie
+end
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
…being added.

`rails/all` loads an awful lot of features, not all of which are useful. This loads only the parts we actually want.

The list that `rails/all` is unpacked into is here https://github.com/rails/rails/blob/main/railties/lib/rails/all.rb

This change is the same code, but with a few lines removed to skip those features.